### PR TITLE
Faster extraction

### DIFF
--- a/src/TML.Files/Extraction/Extractors/RawImgFileExtractor.cs
+++ b/src/TML.Files/Extraction/Extractors/RawImgFileExtractor.cs
@@ -23,20 +23,9 @@ namespace TML.Files.Extraction.Extractors
             ReadOnlySpan<byte> span = data;
             int width = MemoryMarshal.Read<int>(span.Slice(4, 8));
             int height = MemoryMarshal.Read<int>(span.Slice(8, 12));
-            ReadOnlySpan<byte> rgbaValues = span.Slice(12);
+            Memory<byte> rgbaValues = data.AsMemory(12);
 
-            Image<Rgba32> image = new(width, height);
-
-            for (int y = 0; y < height; y++) {
-                for (int x = 0; x < width; x++) {
-                    int index = (y * width + x) * 4;
-                    byte r = rgbaValues[index];
-                    byte g = rgbaValues[index + 1];
-                    byte b = rgbaValues[index + 2];
-                    byte a = rgbaValues[index + 3];
-                    image[x, y] = new Rgba32(r, g, b, a);
-                }
-            }
+            using Image<Rgba32> image = Image.WrapMemory<Rgba32>(Configuration.Default, rgbaValues, width, height);
 
             using MemoryStream stream = new();
             image.SaveAsPng(stream);

--- a/src/TML.Files/Extraction/Extractors/RawImgFileExtractor.cs
+++ b/src/TML.Files/Extraction/Extractors/RawImgFileExtractor.cs
@@ -19,7 +19,6 @@ namespace TML.Files.Extraction.Extractors
 
         /// <inheritdoc cref="IFileExtractor.Extract"/>
         public TModFileData Extract(TModFileEntry entry, byte[] data) {
-            // TODO: optimize this a ton
             ReadOnlySpan<byte> span = data;
             int width = MemoryMarshal.Read<int>(span.Slice(4, 8));
             int height = MemoryMarshal.Read<int>(span.Slice(8, 12));

--- a/src/TML.Files/TML.Files.csproj
+++ b/src/TML.Files/TML.Files.csproj
@@ -33,6 +33,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
+        <PackageReference Include="System.Threading.Tasks.Dataflow" Version="7.0.0" />
     </ItemGroup>
 
 </Project>

--- a/src/TML.Patcher/Commands/ListCommand.cs
+++ b/src/TML.Patcher/Commands/ListCommand.cs
@@ -31,6 +31,5 @@ public class ListCommand : ICommand
             logBlock,
             new RawByteFileExtractor()
         );
-        // foreach (var file in files) await console.Output.WriteLineAsync(file.Path);
     }
 }

--- a/src/TML.Patcher/Commands/ListCommand.cs
+++ b/src/TML.Patcher/Commands/ListCommand.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
 using CliFx;
 using CliFx.Attributes;
 using CliFx.Infrastructure;
@@ -22,11 +23,14 @@ public class ListCommand : ICommand
 
         await console.Output.WriteLineAsync($"Listing files within \"{TModPath}\"...");
 
-        List<TModFileData> files = TModFileExtractor.Extract(
+        ActionBlock<TModFileData> logBlock = new(data => console.Output.WriteLine(data.Path));
+
+        TModFileExtractor.Extract(
             TModFileSerializer.Deserialize(TModPath),
             8,
+            logBlock,
             new RawByteFileExtractor()
         );
-        foreach (var file in files) await console.Output.WriteLineAsync(file.Path);
+        // foreach (var file in files) await console.Output.WriteLineAsync(file.Path);
     }
 }

--- a/src/TML.Tests/ExtractingTest.cs
+++ b/src/TML.Tests/ExtractingTest.cs
@@ -34,7 +34,7 @@ namespace TML.Tests
             var file = TModFileSerializer.Deserialize(tmodFile);
             IFileExtractor[] extractors = {new InfoFileExtractor(), new RawImgFileExtractor(), new RawByteFileExtractor()};
 
-            ConcurrentBag<string> paths = new();
+            List<string> paths = new();
             TModFileExtractor.Extract(file, 8, new ActionBlock<TModFileData>(data => paths.Add(data.Path)), extractors);
             CollectionAssert.AreEquivalent(paths, Files);
         }

--- a/src/TML.Tests/ExtractingTest.cs
+++ b/src/TML.Tests/ExtractingTest.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks.Dataflow;
 using NUnit.Framework;
 using TML.Files;
 using TML.Files.Extraction;
@@ -32,8 +34,9 @@ namespace TML.Tests
             var file = TModFileSerializer.Deserialize(tmodFile);
             IFileExtractor[] extractors = {new InfoFileExtractor(), new RawImgFileExtractor(), new RawByteFileExtractor()};
 
-            IEnumerable<string> extractedFiles = TModFileExtractor.Extract(file, 8, extractors).Select(x => x.Path);
-            CollectionAssert.AreEquivalent(extractedFiles, Files);
+            ConcurrentBag<string> paths = new();
+            TModFileExtractor.Extract(file, 8, new ActionBlock<TModFileData>(data => paths.Add(data.Path)), extractors);
+            CollectionAssert.AreEquivalent(paths, Files);
         }
 
         [Test]
@@ -45,12 +48,13 @@ namespace TML.Tests
 
             if (Directory.Exists("GamerMod")) Directory.Delete("GamerMod", true);
 
-            IEnumerable<TModFileData> extractedFiles = TModFileExtractor.Extract(file, 8, extractors);
-            foreach (var extractedFile in extractedFiles) {
-                string path = Path.Combine("GamerMod", extractedFile.Path);
-                Directory.CreateDirectory(Path.GetDirectoryName(path)!);
-                File.WriteAllBytes(path, extractedFile.Data);
-            }
+            ActionBlock<TModFileData> writeBlock = new(data => {
+                string path = Path.Combine("GamerMod", data.Path);
+                Directory.CreateDirectory(Path.GetDirectoryName(path) ?? "");
+                File.WriteAllBytes(path, data.Data);
+            });
+            
+            TModFileExtractor.Extract(file, 8, writeBlock, extractors);
         }
     }
 }


### PR DESCRIPTION
Increases the speed of mod extraction (Calamity went from ~24s to ~5s according to dotTrace). The main changes are:
 - Using `WrapMemory` in `RawImgFileExtractor.cs`
 - Using `Dataflow` from the `Task Parallel Library`

If you don't want to use Dataflow there is also another option (which can be seen in my [`speed_v2`](https://github.com/Chik3r/TMLPatcher/tree/chik3r/speed_v2) branch), but it is slower than this would be (~9s using that for calamity). The main difference is that it uses a `ConcurrentBag` instead of Dataflow.