### PR TITLE
Complete Final Block

### DIFF
--- a/src/TML.Files/Extraction/TModFileExtractor.cs
+++ b/src/TML.Files/Extraction/TModFileExtractor.cs
@@ -40,6 +40,8 @@ public static class TModFileExtractor
 
         transformBlock.Complete();
         transformBlock.Completion.Wait();
+        finalBlock.Complete();
+        finalBlock.Completion.Wait();
     }
 
     /// <summary>


### PR DESCRIPTION
Completes the `finalBlock` parameter passed into `Extract`. Prevents weird race condition-like issues.